### PR TITLE
Fix pyproject.toml for xai-streamlit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Xircuits component library for streamlit!"
 authors = [{ name = "XpressAI", email = "eduardo@xpress.ai" }]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/XpressAI/xai-mqtt"
+repository = "https://github.com/XpressAI/xai-streamlit"
 keywords = ["xircuits", "streamlit", "data-visualization", "interactive-widgets"]
 
 dependencies = [


### PR DESCRIPTION
# Description

This PR fixes metadata issues in the pyproject.toml of xai-streamlit:

- Corrected `readme` field casing (`README.md` instead of `readme.md`).
- Fixed `repository` URL to point to the correct repo (`xai-streamlit`).
- Ensured `README.md` is properly referenced.
- Verified `default_example_path` points to a valid example

## References

If applicable, note issue numbers this pull request addresses. You can also note any other pull requests that address this issue and how this pull request is different.

## Pull Request Type

- [ ] Xircuits Component Library Code
- [ ] Workflow Example
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Tests

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**1. Test A**

    1. First step
    2. Second step
    3. ...


## Tested on?

- [ ] Windows  
- [ ] Linux Ubuntu 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

# Notes

Add if any.
